### PR TITLE
refs #17 callback params

### DIFF
--- a/app/source/shared-modules/dynamodb-helper/dynamodb-helper.js
+++ b/app/source/shared-modules/dynamodb-helper/dynamodb-helper.js
@@ -291,7 +291,7 @@ DynamoDBHelper.prototype.getDynamoDBDocumentClient = function(credentials, callb
             }.bind(this));
         }
         else
-            callback(docClient);
+            callback(null, docClient);
 
     }
     catch (error) {


### PR DESCRIPTION
in the getDynamoDBDocumentClient callback the first parameter returned is the docClient instance but the callback function expects (error, docClient) as the usage below and througout indicates.