### PR TITLE
Fixed Bug : provide Lambda Authorizer IAM role access to TenantDB

### DIFF
--- a/templates/roles.template
+++ b/templates/roles.template
@@ -5,6 +5,9 @@ Parameters:
   EnvironmentName:
     Description: An environment name that will be prefixed to resource names
     Type: String
+  TenantTableName:
+    Description: The table Name containing tenant information.
+    Type: String
 Resources:
   CleanupRole:
     Type: AWS::IAM::Role
@@ -112,8 +115,19 @@ Resources:
           Statement:
           - Sid: SNS
             Effect: Allow
-            Action: logs:*
-            Resource: arn:aws:logs:*:*:*
+            Action:
+              - logs:*
+            Resource:
+              - arn:aws:logs:*:*:*
+          - Sid: TenantDB
+            Effect: Allow
+            Action:
+              - dynamodb:Get*
+            Resource:
+              - !Sub
+                  - "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TenantTable}"
+                  - TenantTable: !Ref TenantTableName
+
   CloudFormationExecutionRole:
     Type: AWS::IAM::Role
     Properties:

--- a/templates/saas-identity-cognito.template
+++ b/templates/saas-identity-cognito.template
@@ -243,6 +243,7 @@ Resources:
             S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
       Parameters:
         EnvironmentName: !Ref AWS::StackName
+        TenantTableName: !Ref TenantTable
   ZipFiles:
     Type: AWS::CloudFormation::Stack
     Properties:


### PR DESCRIPTION
*Issue #44 
- Lambda Authorizer did not have access to TenantDB

*Description of changes:*
- Added Policy in Lambda Authorizer Execution role to GetItem on TenantDB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
